### PR TITLE
Fix imshow call in edtools.find_rotation_axis

### DIFF
--- a/edtools/find_rotation_axis.py
+++ b/edtools/find_rotation_axis.py
@@ -78,7 +78,7 @@ def cylinder_histo(xyz, bins=(1000, 500)):
 
 def plot_histo(H, xedges, yedges, title="Histogram"):
     """Plot the histogram of the cylindrical projection."""
-    plt.imshow(H.T, interpolation='nearest', origin='low',
+    plt.imshow(H.T, interpolation='nearest', origin='lower',
             extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]],
               vmax=np.percentile(H, 99))
     plt.title(title)

--- a/edtools/find_rotation_axis.py
+++ b/edtools/find_rotation_axis.py
@@ -69,10 +69,10 @@ def cylinder_histo(xyz, bins=(1000, 500)):
     i,j = np.triu_indices(len(xyz), k=1)
     diffs = xyz[i] - xyz[j]
     polar = xyz2cyl(diffs)
-    
+
     px, py = polar.T
     H, xedges, yedges = np.histogram2d(px, py, bins=bins, range=[[-np.pi,np.pi,],[-np.pi/2,np.pi/2]])
-    
+
     return H, xedges, yedges
 
 
@@ -89,12 +89,12 @@ def plot_histo(H, xedges, yedges, title="Histogram"):
     plt.show()
 
 
-def make(arr, omega: float, wavelength: float):  
+def make(arr, omega: float, wavelength: float):
     """
-    Prepare xyz (reciprocal space coordinates) from reflection positions/angle (`arr`), 
+    Prepare xyz (reciprocal space coordinates) from reflection positions/angle (`arr`),
     which is the list of reflections read from XDS (SPOT.XDS)
 
-    omega: rotation axis (degrees), which is defined by the angle between x 
+    omega: rotation axis (degrees), which is defined by the angle between x
         (horizontal axis pointing right) and the rotation axis going in clockwise direction
 
     Note that:
@@ -107,15 +107,15 @@ def make(arr, omega: float, wavelength: float):
 
     omega_rad = np.radians(omega)
     r = make_2d_rotmat(omega_rad)
-    
+
     refs_ = np.dot(reflections, r)
-    
+
     y, x = refs_.T  # NOTE 1
 
     R = 1/wavelength
     C = R - np.sqrt(R**2 - x**2 - y**2).reshape(-1,1)
     xyz = np.c_[x * np.cos(angle), y, -x*np.sin(angle)] + C * np.c_[-np.sin(angle), np.zeros_like(angle), -np.cos(angle)]
-    
+
     return xyz
 
 
@@ -131,33 +131,33 @@ def optimize(arr, omega_start: float, wavelength=float,
     """
 
     r = np.arange(omega_start-plusminus, omega_start+plusminus, step)
-    
+
     best_score = 0
     best_omega = 0
-    
+
     for omega in r:
         xyz = make(arr, omega, wavelength)
-        
+
         nvectors = sum(range(len(xyz)))
-        
+
         H, xedges, yedges = cylinder_histo(xyz, bins=hist_bins)
-      
+
         var = np.var(H)
-        
+
         print(f"Omega: {omega:8.2f}, variance: {var:5.2f}")
-      
+
         if plot:
             plot_histo(H, xedges, yedges, title=f"omega={omega:.2f}$^\circ$ | variance: {var:.2f}")
 
         xvals.append(omega)
         vvals.append(var)
-        
+
         if var > best_score:
             best_omega = omega
             best_score = var
-    
-    print(f"Best omega: {best_omega:.2f}; score: {best_score:.2f}")    
-    
+
+    print(f"Best omega: {best_omega:.2f}; score: {best_score:.2f}")
+
     return best_omega
 
 
@@ -170,7 +170,7 @@ def parse_xds_inp(fn):
         for line in f:
             line = line.split("!", 1)[0].strip()
             match = False
-            
+
             if "X-RAY_WAVELENGTH" in line:
                 match = True
                 wavelength = float(line.rsplit("X-RAY_WAVELENGTH=")[1].split()[0])
@@ -196,7 +196,7 @@ def parse_xds_inp(fn):
                 match = True
                 inp = line.rsplit("ROTATION_AXIS=")[1].split()[0:3]
                 rotx, roty, rotz = [float(val) for val in inp]
-            
+
             if match:
                 print(line)
 
@@ -225,7 +225,7 @@ def load_spot_xds(fn, beam_center: [float, float], osc_angle: float, pixelsize: 
 
     reflections = arr[:,0:2] - beam_center
     angle = arr[:,2] * osc_angle_rad
-    
+
     reflections *= pixelsize
 
     return np.c_[reflections, angle]
@@ -241,7 +241,7 @@ Usage: python find_rotation_axis.py XDS.INP"""
 
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-        
+
     parser.add_argument("args",
                         type=str, nargs="?", metavar="FILE",
                         help="Path to XDS.INP file (also reads SPOT.XDS in the same directory)")
@@ -268,7 +268,7 @@ Usage: python find_rotation_axis.py XDS.INP"""
                         finetune=False,
                         opposite=False,
                         omega_input=None)
-    
+
     options = parser.parse_args()
 
     xds_inp = options.args
@@ -315,17 +315,17 @@ Usage: python find_rotation_axis.py XDS.INP"""
     arr = load_spot_xds(spot_xds, beam_center, osc_angle, pixelsize)
 
     hist_bins = 1000, 500
-    
+
     if options.view:
-        omega_final = omega_current  
+        omega_final = omega_current
     elif options.optimize:
         global xvals
         global vvals
         xvals = []
         vvals = []
-        
+
         omega_global = omega_local = omega_fine = 0
-        
+
         if options.finetune:
             omega_start = omega_tmp = omega_global = omega_current
         else:
@@ -333,26 +333,26 @@ Usage: python find_rotation_axis.py XDS.INP"""
             omega_global = omega_tmp = optimize(arr, omega_tmp, wavelength, plusminus=180, step=5, hist_bins=hist_bins)
 
         omega_local = omega_tmp = optimize(arr, omega_tmp, wavelength, plusminus=5, step=1, hist_bins=hist_bins)
-        
+
         omega_fine = omega_tmp = optimize(arr, omega_tmp, wavelength, plusminus=1, step=0.1, hist_bins=hist_bins)
-        
+
         omega_final = omega_tmp
-        
+
         print("---")
         print(f"Best omega (global search): {omega_global:.3f}")
         print(f"Best omega (local search): {omega_local:.3f}")
         print(f"Best omega (fine search): {omega_fine:.3f}")
-    
+
     xyz = make(arr, omega_final, wavelength)
     H, xedges, yedges = cylinder_histo(xyz)
-    
+
     var = np.var(H)
     print(f"Variance: {var:.2f}")
-    
+
     # check opposite
     xyz_opp = make(arr, omega_final+180, wavelength)
     H_opp, xedges_opp, yedges_opp = cylinder_histo(xyz_opp)
-    
+
     var_opp = np.var(H_opp)
     print(f"Variance (opposite): {var_opp:.2f}")
 
@@ -371,35 +371,35 @@ Usage: python find_rotation_axis.py XDS.INP"""
 
     omega_deg = omega_final
     omega_rad = np.radians(omega_final)
-    
+
     print(f"\nRotation axis found: {omega_deg:.2f} deg. / {omega_rad:.3f} rad.")
-    
+
     print(" - Instamatic (config/camera/camera_name.yaml)")
     omega_instamatic = omega_rad
     print(f"    rotation_axis_vs_stage_xy: {omega_instamatic:.3f}")
-    
+
     print(" - XDS")
     rot_x_xds, rot_y_xds, rot_z_xds = rotation_axis_to_xyz(omega_rad, setting="xds")
     print(f"    ROTATION_AXIS= {rot_x_xds:.4f} {rot_y_xds:.4f} {rot_z_xds:.4f}")
     print(" - XDS (opposite rotation)")
     rot_x_xds, rot_y_xds, rot_z_xds = rotation_axis_to_xyz(omega_rad, setting="xds", invert=True)
     print(f"    ROTATION_AXIS= {rot_x_xds:.4f} {rot_y_xds:.4f} {rot_z_xds:.4f}")
-    
+
     print(" - DIALS")
     rot_x_dials, rot_y_dials, rot_z_dials = rotation_axis_to_xyz(omega_rad, setting="dials")
     print(f"    geometry.goniometer.axes={rot_x_dials:.4f},{rot_y_dials:.4f},{rot_z_dials:.4f}")
     print(" - DIALS (opposite rotation)")
     rot_x_dials, rot_y_dials, rot_z_dials = rotation_axis_to_xyz(omega_rad, setting="dials", invert=True)
     print(f"    geometry.goniometer.axes={rot_x_dials:.4f},{rot_y_dials:.4f},{rot_z_dials:.4f}")
-    
+
     print(" - PETS (.pts)")
     omega_pets = omega_deg
     if omega_pets < 0:
         omega_pets += 360
     elif omega_pets > 360:
-        omega_pets -= 360 
+        omega_pets -= 360
     print(f"    omega {omega_pets:.2f}")
-    
+
     print(" - RED (.ed3d)")
     omega_red = omega_deg
     if omega_red < -180:


### PR DESCRIPTION
`edtools.find_rotation_axis XDS.INP` crashed for me with 

```
Traceback (most recent call last):
  File "/home/fcx32934/sw/cctbx/conda_base/bin/edtools.find_rotation_axis", line 8, in <module>
    sys.exit(main())
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/edtools/find_rotation_axis.py", line 362, in main
    plot_histo(H, xedges, yedges, title=f"omega={omega_final:.2f}$^\circ$ | var={var:.2f}")
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/edtools/find_rotation_axis.py", line 81, in plot_histo
    plt.imshow(H.T, interpolation='nearest', origin='low',
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/matplotlib/pyplot.py", line 2724, in imshow
    __ret = gca().imshow(
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/matplotlib/__init__.py", line 1447, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/matplotlib/axes/_axes.py", line 5519, in imshow
    im = mimage.AxesImage(self, cmap, norm, interpolation, origin, extent,
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/matplotlib/image.py", line 902, in __init__
    super().__init__(
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/matplotlib/image.py", line 246, in __init__
    cbook._check_in_list(["upper", "lower"], origin=origin)
  File "/home/fcx32934/sw/cctbx/conda_base/lib/python3.8/site-packages/matplotlib/cbook/__init__.py", line 2266, in _check_in_list
    raise ValueError(
ValueError: 'low' is not a valid value for origin; supported values are 'upper', 'lower'
```

This PR fixes that for the version of matplotlib I am using (3.3.4). I checked the docs for the minimum version for edtools (3.2.1), and the form `origin="lower"` appears to be fine there too.