### PR TITLE
Make 'make_shelx' windows compatible

### DIFF
--- a/edtools/make_shelx.py
+++ b/edtools/make_shelx.py
@@ -5,9 +5,9 @@ from shutil import which
 import sys
 
 
-if which("sginfo"):
+if e := which("sginfo"):
     exe = "sginfo"
-elif which("cctbx.python"):
+elif e := which("cctbx.python"):
     exe = "cctbx.python"
 else:
     sys.exit("Either sginfo or cctbx.python must be in the path")
@@ -27,15 +27,14 @@ def comp2dict(composition):
 
 def get_latt_symm_cards(spgr):
     if exe == "sginfo":
-        cmd = [exe, spgr, '-Shelx']
+        cmd = [e, spgr, '-Shelx']
     elif exe == "cctbx.python":
-        script = ("from cctbx import sgtbx\n"
-                  "from iotbx.shelx.write_ins import LATT_SYMM\n"
-                  "import sys\n"
-                  "space_group_info = sgtbx.space_group_info(\n"
-                  f"    symbol='{spgr}')\n"
-                  "LATT_SYMM(sys.stdout, space_group_info.group())\n")
-        cmd = [exe, "-c", script]
+        script = ("from cctbx import sgtbx;"
+                  "from iotbx.shelx.write_ins import LATT_SYMM;"
+                  "import sys;"
+                  f"space_group_info = sgtbx.space_group_info(symbol='{spgr}');"
+                  "LATT_SYMM(sys.stdout, space_group_info.group());")
+        cmd = [e, "-c", script]
 
     p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.STDOUT)
     out, err = p.communicate()

--- a/edtools/make_shelx.py
+++ b/edtools/make_shelx.py
@@ -5,10 +5,10 @@ from shutil import which
 import sys
 
 
-if e := which("sginfo"):
-    exe = "sginfo"
-elif e := which("cctbx.python"):
-    exe = "cctbx.python"
+if exe := which("sginfo"):
+    context = "sginfo"
+elif exe := which("cctbx.python"):
+    context = "cctbx.python"
 else:
     sys.exit("Either sginfo or cctbx.python must be in the path")
 
@@ -26,15 +26,15 @@ def comp2dict(composition):
 
 
 def get_latt_symm_cards(spgr):
-    if exe == "sginfo":
-        cmd = [e, spgr, '-Shelx']
-    elif exe == "cctbx.python":
+    if context == "sginfo":
+        cmd = [exe, spgr, '-Shelx']
+    elif context == "cctbx.python":
         script = ("from cctbx import sgtbx;"
                   "from iotbx.shelx.write_ins import LATT_SYMM;"
                   "import sys;"
                   f"space_group_info = sgtbx.space_group_info(symbol='{spgr}');"
                   "LATT_SYMM(sys.stdout, space_group_info.group());")
-        cmd = [e, "-c", script]
+        cmd = [exe, "-c", script]
 
     p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.STDOUT)
     out, err = p.communicate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"License :: OSI Approved :: BSD License",
 	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.6",
-	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
 ]
@@ -33,7 +31,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.6.1"
+python = ">=3.8.0"
 numpy = ">=1.18.2"
 matplotlib = ">=3.2.1"
 scipy = ">=1.4.1"

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='edtools',
-    version='1.0.3',
+    version='1.0.4',
     description='Collection of tools for automated processing and clustering of electron diffraction data.',
-    python_requires='>=3.6.1',
+    python_requires='>=3.8.0',
     project_urls={
         'documentation': 'http://github.com/instamatic-dev/edtools',
         'homepage': 'http://github.com/instamatic-dev/edtools',
@@ -36,8 +36,6 @@ setup(
             'Development Status :: 5 - Stable',
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
     ],


### PR DESCRIPTION
'\n' newlines made the generated program not work on windows, since windows expects \r\n (i think). Using semicolons, while not very pythonic, made the script work on cctbx.python installed on python.

setting the result of which to the variable e also lets us run it on windows, as the true command is "cctbx.python.bat" rather than cctbx.python